### PR TITLE
Set Up Azure Clients w/ Traditional Auth

### DIFF
--- a/src/Azureference.Web/Azureference.Web.csproj
+++ b/src/Azureference.Web/Azureference.Web.csproj
@@ -5,6 +5,8 @@
     <UserSecretsId>fc14af8d-b07a-4897-8584-0fd9e4e42493</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.2.3" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
     <PackageReference Include="MinVer" Version="2.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Azureference.Web/Azureference.Web.csproj
+++ b/src/Azureference.Web/Azureference.Web.csproj
@@ -5,9 +5,12 @@
     <UserSecretsId>fc14af8d-b07a-4897-8584-0fd9e4e42493</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
     <PackageReference Include="MinVer" Version="2.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Linq.Async" Version="4.1.1" />
+    <PackageReference Include="System.Reactive.Linq" Version="4.4.1" />
   </ItemGroup>
 </Project>

--- a/src/Azureference.Web/Azureference.Web.csproj
+++ b/src/Azureference.Web/Azureference.Web.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Azure.Identity" Version="1.2.3" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.8" />
     <PackageReference Include="MinVer" Version="2.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Azureference.Web/Infrastructure/DemoContext.cs
+++ b/src/Azureference.Web/Infrastructure/DemoContext.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace Azureference.Web.Infrastructure
+{
+    public class DemoContext : DbContext
+    {
+        public DemoContext(DbContextOptions<DemoContext> options) : base(options)
+        {
+        }
+    }
+}

--- a/src/Azureference.Web/Pages/Database.cshtml
+++ b/src/Azureference.Web/Pages/Database.cshtml
@@ -1,0 +1,23 @@
+﻿@page
+@model Azureference.Web.Pages.Database
+@{
+    ViewData["Title"] = "Database";
+}
+
+<h1>Database</h1>
+
+<h2>Azure SQL</h2>
+
+<p>
+    The database
+    @if (Model.CanConnect && string.IsNullOrEmpty(Model.ErrorMessage))
+        { <span class="text-success">CAN</span> }
+    else
+        { <span class="text-danger">CANNOT</span> }
+    connect.
+</p>
+
+@if (!string.IsNullOrEmpty(@Model.ErrorMessage))
+{
+    <p>@Model.ErrorMessage</p>
+}

--- a/src/Azureference.Web/Pages/Database.cshtml.cs
+++ b/src/Azureference.Web/Pages/Database.cshtml.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading.Tasks;
+using Azureference.Web.Infrastructure;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Azureference.Web.Pages
+{
+    public class Database : PageModel
+    {
+        private readonly DemoContext _db;
+
+        public Database(DemoContext db)
+        {
+            _db = db;
+        }
+
+        public bool CanConnect { get; private set; }
+        public string ErrorMessage { get; private set; }
+
+        public async Task OnGetAsync()
+        {
+            try
+            {
+                CanConnect = await _db.Database.CanConnectAsync();
+            }
+            catch (Exception e)
+            {
+                ErrorMessage = e.Message;
+            }
+        }
+    }
+}

--- a/src/Azureference.Web/Pages/Files.cshtml
+++ b/src/Azureference.Web/Pages/Files.cshtml
@@ -8,16 +8,25 @@
 
 <h2>Azure Blob Storage</h2>
 
-<p>Here are the blobs in the <span class="text-info">@Model.ContainerName</span> container:</p>
+@if (string.IsNullOrEmpty(@Model.ErrorMessage))
+{
 
-<ul>
-    @if (!Model.Blobs.Any())
-    {
-        <li><em>No Blobs in this container.</em></li>
-    }
+    <p>Here are the blobs in the <span class="text-info">@Model.ContainerName</span> container:</p>
 
-    @foreach (var blob in Model.Blobs)
-    {
-        <li>@blob.Name</li>
-    }
-</ul>
+    <ul>
+        @if (!Model.Blobs.Any())
+        {
+            <li><em>No Blobs in this container.</em></li>
+        }
+
+        @foreach (var blob in Model.Blobs)
+        {
+            <li>@blob.Name</li>
+        }
+    </ul>
+}
+else
+{
+    <h3 class="text-danger">Fetching Blobs Failed</h3>
+    <p>@Model.ErrorMessage</p>
+}

--- a/src/Azureference.Web/Pages/Files.cshtml
+++ b/src/Azureference.Web/Pages/Files.cshtml
@@ -1,0 +1,23 @@
+﻿@page
+@model Azureference.Web.Pages.Files
+@{
+    ViewData["Title"] = "Files";
+}
+
+<h1>Files</h1>
+
+<h2>Azure Blob Storage</h2>
+
+<p>Here are the blobs in the <span class="text-info">@Model.ContainerName</span> container:</p>
+
+<ul>
+    @if (!Model.Blobs.Any())
+    {
+        <li><em>No Blobs in this container.</em></li>
+    }
+
+    @foreach (var blob in Model.Blobs)
+    {
+        <li>@blob.Name</li>
+    }
+</ul>

--- a/src/Azureference.Web/Pages/Files.cshtml.cs
+++ b/src/Azureference.Web/Pages/Files.cshtml.cs
@@ -26,7 +26,7 @@ namespace Azureference.Web.Pages
         {
             try
             {
-                var connectionString = _config.GetValue<string>("Files:ConnectionString");
+                var connectionString = _config.GetConnectionString("StorageAccount");
                 var blobContainerClient = new BlobContainerClient(connectionString, ContainerName);
 
                 if (!blobContainerClient.Exists())

--- a/src/Azureference.Web/Pages/Files.cshtml.cs
+++ b/src/Azureference.Web/Pages/Files.cshtml.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Azure.Storage.Blobs;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Configuration;
+
+namespace Azureference.Web.Pages
+{
+    public class Files : PageModel
+    {
+        private readonly IConfiguration _config;
+
+        public Files(IConfiguration config)
+        {
+            _config = config;
+            ContainerName = _config.GetValue<string>("Files:BlobContainerName");
+        }
+
+        public string ContainerName { get; }
+        public IEnumerable<BlobModel> Blobs { get; private set; }
+
+        public async Task OnGetAsync()
+        {
+            var connectionString = _config.GetValue<string>("Files:ConnectionString");
+            var blobContainerClient = new BlobContainerClient(connectionString, ContainerName);
+
+            if (!blobContainerClient.Exists())
+            {
+                Blobs = Enumerable.Empty<BlobModel>();
+            }
+            else
+            {
+                Blobs = await blobContainerClient.GetBlobsAsync()
+                    .Select(b => new BlobModel(b.Name))
+                    .ToListAsync();
+            }
+        }
+
+
+        public class BlobModel
+        {
+            public string Name { get; }
+
+            public BlobModel(string name)
+            {
+                Name = name;
+            }
+        }
+    }
+}

--- a/src/Azureference.Web/Pages/KeyVault.cshtml
+++ b/src/Azureference.Web/Pages/KeyVault.cshtml
@@ -1,0 +1,24 @@
+﻿@page
+@model Azureference.Web.Pages.KeyVault
+@{
+    ViewData["Title"] = "Key Vault";
+}
+
+<h1>Azure Key Vault</h1>
+
+<h2>Secrets</h2>
+
+@if (string.IsNullOrEmpty(Model.ErrorMessage))
+{
+    <p>
+        The value of the secret called
+        <span class="text-info">@Model.SecretName</span> is
+        <span class="text-success">@Model.SecretValue</span>
+    </p>
+}
+else
+{
+    <h3 class="text-danger">Fetching Secrets Failed</h3>
+    <p>@Model.ErrorMessage</p>
+}
+

--- a/src/Azureference.Web/Pages/KeyVault.cshtml.cs
+++ b/src/Azureference.Web/Pages/KeyVault.cshtml.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Configuration;
+
+namespace Azureference.Web.Pages
+{
+    public class KeyVault : PageModel
+    {
+        private readonly IConfiguration _config;
+
+        public KeyVault(IConfiguration config)
+        {
+            _config = config;
+            SecretName = _config.GetValue<string>("KeyVault:DemoSecretName");
+        }
+
+        public string SecretName { get; }
+        public string SecretValue { get; private set; }
+        public string ErrorMessage { get; private set; }
+
+        public async Task OnGetAsync()
+        {
+            try
+            {
+                var keyVaultUri = _config.GetValue<string>("KeyVault:Uri");
+                var client = new SecretClient(new Uri(keyVaultUri), GetClientCredential());
+                var secret = await client.GetSecretAsync(SecretName);
+
+                SecretValue = secret.Value.Value;
+            }
+            catch (Exception e)
+            {
+                ErrorMessage = e.Message;
+            }
+        }
+
+
+        private TokenCredential GetClientCredential()
+        {
+            var tenantId = _config.GetValue<string>("AzureAD:TenantId");
+            var clientId = _config.GetValue<string>("AzureAD:ClientId");
+            var clientSecret = _config.GetValue<string>("AzureAD:ClientSecret");
+
+            return new ClientSecretCredential(tenantId, clientId, clientSecret);
+        }
+    }
+}

--- a/src/Azureference.Web/Pages/Shared/_Layout.cshtml
+++ b/src/Azureference.Web/Pages/Shared/_Layout.cshtml
@@ -19,9 +19,8 @@
                 </button>
                 <div class="navbar-collapse collapse d-sm-inline-flex flex-sm-row-reverse">
                     <ul class="navbar-nav flex-grow-1">
-                        <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-page="/Index">Home</a>
-                        </li>
+                        <li class="nav-item"><a class="nav-link text-dark" asp-area="" asp-page="/Index">Home</a></li>
+                        <li class="nav-item"><a class="nav-link text-dark" asp-area="" asp-page="/Files">Files</a></li>
                     </ul>
                 </div>
             </div>

--- a/src/Azureference.Web/Pages/Shared/_Layout.cshtml
+++ b/src/Azureference.Web/Pages/Shared/_Layout.cshtml
@@ -21,6 +21,7 @@
                     <ul class="navbar-nav flex-grow-1">
                         <li class="nav-item"><a class="nav-link text-dark" asp-area="" asp-page="/Index">Home</a></li>
                         <li class="nav-item"><a class="nav-link text-dark" asp-area="" asp-page="/Files">Files</a></li>
+                        <li class="nav-item"><a class="nav-link text-dark" asp-area="" asp-page="/Database">Database</a></li>
                         <li class="nav-item"><a class="nav-link text-dark" asp-area="" asp-page="/KeyVault">KeyVault</a></li>
                     </ul>
                 </div>

--- a/src/Azureference.Web/Pages/Shared/_Layout.cshtml
+++ b/src/Azureference.Web/Pages/Shared/_Layout.cshtml
@@ -21,6 +21,7 @@
                     <ul class="navbar-nav flex-grow-1">
                         <li class="nav-item"><a class="nav-link text-dark" asp-area="" asp-page="/Index">Home</a></li>
                         <li class="nav-item"><a class="nav-link text-dark" asp-area="" asp-page="/Files">Files</a></li>
+                        <li class="nav-item"><a class="nav-link text-dark" asp-area="" asp-page="/KeyVault">KeyVault</a></li>
                     </ul>
                 </div>
             </div>

--- a/src/Azureference.Web/Startup.cs
+++ b/src/Azureference.Web/Startup.cs
@@ -2,9 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Azureference.Web.Infrastructure;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.HttpsPolicy;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -24,6 +26,8 @@ namespace Azureference.Web
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddRazorPages();
+            services.AddDbContext<DemoContext>(options =>
+                options.UseSqlServer(Configuration.GetConnectionString("SqlServer")));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/Azureference.Web/appsettings.json
+++ b/src/Azureference.Web/appsettings.json
@@ -4,6 +4,17 @@
     "ConnectionString": "UseDevelopmentStorage=true"
   },
 
+  "AzureAD": {
+    "TenantId": "",
+    "ClientId": "",
+    "ClientSecret": ""
+  },
+
+  "KeyVault": {
+    "Uri": "",
+    "DemoSecretName": "DemoSecret"
+  },
+
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/Azureference.Web/appsettings.json
+++ b/src/Azureference.Web/appsettings.json
@@ -1,4 +1,9 @@
 {
+  "Files": {
+    "BlobContainerName": "Demo",
+    "ConnectionString": "UseDevelopmentStorage=true"
+  },
+
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/Azureference.Web/appsettings.json
+++ b/src/Azureference.Web/appsettings.json
@@ -1,11 +1,11 @@
 {
   "ConnectionStrings": {
-    "SqlServer": "Server=.\\sqlexpress;Database=Azureference;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "SqlServer": "Server=.\\sqlexpress;Database=Azureference;Trusted_Connection=True;MultipleActiveResultSets=true",
+    "StorageAccount": "UseDevelopmentStorage=true"
   },
 
   "Files": {
-    "BlobContainerName": "Demo",
-    "ConnectionString": "UseDevelopmentStorage=true"
+    "BlobContainerName": "Demo"
   },
 
   "AzureAD": {

--- a/src/Azureference.Web/appsettings.json
+++ b/src/Azureference.Web/appsettings.json
@@ -1,4 +1,8 @@
 {
+  "ConnectionStrings": {
+    "SqlServer": "Server=.\\sqlexpress;Database=Azureference;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
+
   "Files": {
     "BlobContainerName": "Demo",
     "ConnectionString": "UseDevelopmentStorage=true"


### PR DESCRIPTION
Add Azure client demos for Blob Storage, Azure SQL, and Key Vault, using "traditional" connection authentication styles:

- Blob Storage: Connection String + Container Name
- Azure SQL: Connection String
- KeyVault: Service Principal (App Registration) Token

App Setting defaults are for a local-OK setup which doesn't make sense but it seemed better than keeping them blank.