### PR TITLE
Authorize Services w/ Managed Identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ pwsh ./setup.ps1
 
 ### Local Settings
 
+**You MUST update settings for app to work, it's in Azure, after all.**
+
 Override default app settings with the [dotnet secret manager](https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-3.1&tabs=windows#set-a-secret):
 
 ```shell

--- a/src/Azureference.Web/Infrastructure/DemoContext.cs
+++ b/src/Azureference.Web/Infrastructure/DemoContext.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Identity;
+using Microsoft.EntityFrameworkCore;
 
 namespace Azureference.Web.Infrastructure
 {
@@ -6,6 +9,18 @@ namespace Azureference.Web.Infrastructure
     {
         public DemoContext(DbContextOptions<DemoContext> options) : base(options)
         {
+            AddTokenToConnection().Wait();
         }
+
+        private async Task AddTokenToConnection()
+        {
+            var connection = (Microsoft.Data.SqlClient.SqlConnection)Database.GetDbConnection();
+
+            var tokenRequestContext = new TokenRequestContext(new[] { "https://database.windows.net//.default" });
+            var tokenRequestResult = await new DefaultAzureCredential().GetTokenAsync(tokenRequestContext);
+
+            connection.AccessToken = tokenRequestResult.Token;
+        }
+
     }
 }

--- a/src/Azureference.Web/Pages/Files.cshtml.cs
+++ b/src/Azureference.Web/Pages/Files.cshtml.cs
@@ -11,11 +11,8 @@ namespace Azureference.Web.Pages
 {
     public class Files : PageModel
     {
-        private readonly IConfiguration _config;
-
         public Files(IConfiguration config)
         {
-            _config = config;
             ContainerUri = new Uri(config.GetValue<string>("Files:BlobContainerUri"));
         }
 

--- a/src/Azureference.Web/Pages/Files.cshtml.cs
+++ b/src/Azureference.Web/Pages/Files.cshtml.cs
@@ -42,7 +42,6 @@ namespace Azureference.Web.Pages
             {
                 ErrorMessage = e.Message;
             }
-            
         }
 
         public class BlobModel

--- a/src/Azureference.Web/Pages/Files.cshtml.cs
+++ b/src/Azureference.Web/Pages/Files.cshtml.cs
@@ -16,12 +16,11 @@ namespace Azureference.Web.Pages
         public Files(IConfiguration config)
         {
             _config = config;
-            ContainerName = _config.GetValue<string>("Files:BlobContainerName");
             ContainerUri = new Uri(config.GetValue<string>("Files:BlobContainerUri"));
         }
 
-        public string ContainerName { get; }
         public Uri ContainerUri { get; }
+        public string ContainerName => ContainerUri.Segments.Last();
         public string ErrorMessage { get; private set; }
         public IEnumerable<BlobModel> Blobs { get; private set; }
 

--- a/src/Azureference.Web/Pages/Files.cshtml.cs
+++ b/src/Azureference.Web/Pages/Files.cshtml.cs
@@ -28,8 +28,7 @@ namespace Azureference.Web.Pages
         {
             try
             {
-                var connectionString = _config.GetConnectionString("StorageAccount");
-                var blobContainerClient = new BlobContainerClient(connectionString, ContainerName);
+                var blobContainerClient = new BlobContainerClient(ContainerUri, new DefaultAzureCredential());
 
                 if (!blobContainerClient.Exists())
                 {

--- a/src/Azureference.Web/Pages/Files.cshtml.cs
+++ b/src/Azureference.Web/Pages/Files.cshtml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Azure.Identity;
 using Azure.Storage.Blobs;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Configuration;
@@ -16,9 +17,11 @@ namespace Azureference.Web.Pages
         {
             _config = config;
             ContainerName = _config.GetValue<string>("Files:BlobContainerName");
+            ContainerUri = new Uri(config.GetValue<string>("Files:BlobContainerUri"));
         }
 
         public string ContainerName { get; }
+        public Uri ContainerUri { get; }
         public string ErrorMessage { get; private set; }
         public IEnumerable<BlobModel> Blobs { get; private set; }
 

--- a/src/Azureference.Web/Pages/KeyVault.cshtml.cs
+++ b/src/Azureference.Web/Pages/KeyVault.cshtml.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using Azure.Core;
 using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -27,7 +26,7 @@ namespace Azureference.Web.Pages
             try
             {
                 var keyVaultUri = _config.GetValue<string>("KeyVault:Uri");
-                var client = new SecretClient(new Uri(keyVaultUri), GetClientCredential());
+                var client = new SecretClient(new Uri(keyVaultUri), new DefaultAzureCredential());
                 var secret = await client.GetSecretAsync(SecretName);
 
                 SecretValue = secret.Value.Value;
@@ -36,16 +35,6 @@ namespace Azureference.Web.Pages
             {
                 ErrorMessage = e.Message;
             }
-        }
-
-
-        private TokenCredential GetClientCredential()
-        {
-            var tenantId = _config.GetValue<string>("AzureAD:TenantId");
-            var clientId = _config.GetValue<string>("AzureAD:ClientId");
-            var clientSecret = _config.GetValue<string>("AzureAD:ClientSecret");
-
-            return new ClientSecretCredential(tenantId, clientId, clientSecret);
         }
     }
 }

--- a/src/Azureference.Web/appsettings.json
+++ b/src/Azureference.Web/appsettings.json
@@ -1,7 +1,6 @@
 {
   "ConnectionStrings": {
     "SqlServer": "Server=tcp:{server-name}.database.windows.net,1433;Initial Catalog=MySqlDB;Persist Security Info=False;User ID={username};Password={password};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;",
-    "StorageAccount": "DefaultEndpointsProtocol=https;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
   },
 
   "Files": {

--- a/src/Azureference.Web/appsettings.json
+++ b/src/Azureference.Web/appsettings.json
@@ -5,7 +5,8 @@
   },
 
   "Files": {
-    "BlobContainerName": "demo"
+    "BlobContainerName": "demo",
+    "BlobContainerUri": "https://devstoreaccount1.blob.core.windows.net/demo"
   },
 
   "AzureAD": {

--- a/src/Azureference.Web/appsettings.json
+++ b/src/Azureference.Web/appsettings.json
@@ -5,7 +5,6 @@
   },
 
   "Files": {
-    "BlobContainerName": "demo",
     "BlobContainerUri": "https://devstoreaccount1.blob.core.windows.net/demo"
   },
 

--- a/src/Azureference.Web/appsettings.json
+++ b/src/Azureference.Web/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "SqlServer": "Server=tcp:{server-name}.database.windows.net,1433;Initial Catalog=MySqlDB;Persist Security Info=False;User ID={username};Password={password};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;",
+    "SqlServer": "Server=tcp:{server-name}.database.windows.net,1433;Initial Catalog={database-name};Persist Security Info=False;User ID={username};Password={password};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;",
   },
 
   "Files": {

--- a/src/Azureference.Web/appsettings.json
+++ b/src/Azureference.Web/appsettings.json
@@ -7,12 +7,6 @@
     "BlobContainerUri": "https://devstoreaccount1.blob.core.windows.net/demo"
   },
 
-  "AzureAD": {
-    "TenantId": "00000000-0000-0000-0000-000000000000",
-    "ClientId": "00000000-0000-0000-0000-000000000000",
-    "ClientSecret": "{client-secret}"
-  },
-
   "KeyVault": {
     "Uri": "https://{keyvault-name}.vault.azure.net/",
     "DemoSecretName": "DemoSecret"

--- a/src/Azureference.Web/appsettings.json
+++ b/src/Azureference.Web/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "SqlServer": "Server=tcp:{server-name}.database.windows.net,1433;Initial Catalog={database-name};Persist Security Info=False;User ID={username};Password={password};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;",
+    "SqlServer": "Server=tcp:{server-name}.database.windows.net,1433;Initial Catalog={database-name};Persist Security Info=False;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;",
   },
 
   "Files": {


### PR DESCRIPTION
Replace regular 'ol authorization schemes (keys, service principals, passwords) for Azure Clients with Managed Identity

- use token + storage URI for blobs
  - replacing connection string + container name
- add token to EF connection at Context build-time
  - replacing username + password in connection string
- use `Default` token for KeyVault
  - replace explicit token that used AD App + client secret

At its current state, the app won't run locally; it's just for in-Azure